### PR TITLE
Update Jupyterlab_server to 2.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.7.2" %}
-{% set hash = "c6c9ae5796ed60c65bccd84503cbd44b9e35b046b8265f24db3cc4d61631fc0d" %}
+{% set version = "2.8.1" %}
+{% set hash = "39fd519e9b3275873bd15de891363c28f2649814f7bbc11c57469c60e8408e97" %}
 
 package:
   name: jupyterlab_server


### PR DESCRIPTION
1. check the upstream
2. check the pinning
3. check license
4. check changelog
   https://github.com/jupyterlab/jupyterlab_server/blob/master/CHANGELOG.md
   there were only bug fixes mentioned on the changelog, 
   Fall back to `DEFAULT_LOCALE` when translation settings schema is invalid in get_current_locale #207
   also in version 2.8.0 only updates were made, but no breaking changes were mentioned
5. check dev_url
6. check doc_url
7. verify that pip is checked
8. verify that wheel is present
9. verify the test section
10. additional research
      there were no open issues mentioned in conda-forge
       https://github.com/conda-forge/jupyterlab_server-feedstock/issues
11.  additional tests
       the following command was used for testing `conda-build jupyterlab_server-feedstock --test`
       the result of the test was as follows `All tests passed`
       One of the packages that make use of `jupyterlab_server` is `jupyterlab`
       In order to test the package, the requirements for `jupyterlab` in the meta.yaml were modified to have 
       `jupyterlab_server` make use of `jupyterlab_server 2.8.1` then the `jupyterlab` package was built 
        successfully.  
        
        In addition a test was done on the newly built `jupyterlab` package by running the following 
        command: `conda-build jupyterlab-feedstock --test`

        The result was the following: `All tests passed`
        
        We can see that we were able to build other packages using `jupyterlab_server`
        
        To make sure that the package can be installed properly an import test was performed in addition by doing  
        a conda install command by specifying the version of jupyterlab_server that was going to be tested. 
        `conda install jupyterlab_server=2.8.1`
        
based on all of the results from research and tests we can conclude that the package is safe to update