### PR TITLE
jupyterlab_server 2.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 
 build:
   number: 0
+  # This package isn't included in SOW Packages list and 
+  # Unsatisfiable dependencies for platform noarch: nodejs >=14,<15 
+  skip: True  # [s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,6 @@ test:
     - jupyterlab_server
   commands:
     - python -m pip check
-  downstreams:
-    - jupyterlab
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.8.2" %}
-{% set hash = "26d813c8162c83d466df7d155865987dabe70aa452f9187dfb79fd88afc8fa0b" %}
+{% set version = "2.10.1" %}
+{% set hash = "9683d661fc059ae4e2039b582d0d80cec96778dad581bd27b5941a06191397ba" %}
 
 package:
   name: jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.10.1" %}
-{% set hash = "9683d661fc059ae4e2039b582d0d80cec96778dad581bd27b5941a06191397ba" %}
+{% set version = "2.10.2" %}
+{% set hash = "bf1ec9e49d4e26f14d70055cc293b3f8ec8410f95a4d5b4bd55c442d9b8b266c" %}
 
 package:
   name: jupyterlab_server
@@ -20,8 +20,8 @@ build:
 
 requirements:
   host:
-    - pip
     - python
+    - pip
     - jupyter-packaging >=0.9,<2
     - jupyter_server
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,6 @@ source:
 
 build:
   number: 0
-  # This package isn't included in SOW Packages list and 
-  # Unsatisfiable dependencies for platform noarch: nodejs >=14,<15 
-  skip: True  # [s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - jupyter-packaging >=0.9,<2
     - jupyter_server
     - setuptools
@@ -30,17 +30,20 @@ requirements:
     - json5
     - jsonschema >=3.0.1
     - jinja2 >=2.10
+    - jupyter_server >=1.4,<2
     - packaging
     - requests
-    - jupyter_server >=1.4,<2
 
 test:
   requires:
     - pip
+    - python <3.10
   imports:
     - jupyterlab_server
   commands:
     - python -m pip check
+  downstreams:
+    - jupyterlab
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server


### PR DESCRIPTION
Update jupyterlab_server to 2.10.2

Version change: bump version number from 2.8.2 to 2.10.2
Bug Tracker: new open issues https://github.com/jupyterlab/jupyterlab_server/issues
Github releases:  https://github.com/jupyterlab/jupyterlab_server/releases
Upstream license:  License file:  https://github.com/jupyterlab/jupyterlab_server/blob/master/LICENSE
Upstream Changelog: https://github.com/jupyterlab/jupyterlab_server/blob/main/CHANGELOG.md
Upstream setup.cfg:  https://github.com/jupyterlab/jupyterlab_server/blob/v2.10.2/setup.cfg
Upstream pyproject.toml:  https://github.com/jupyterlab/jupyterlab_server/blob/v2.10.2/pyproject.toml

The package jupyterlab_server is mentioned inside the packages:
jupyterlab |

Actions:
1. Fix python in host and test/requires
2. Add `jupyter_server 1.4.1` on a`rm64`
3. Skip `s390x`: This package isn't included in SOW Packages list and Unsatisfiable dependencies for platform noarch:` nodejs >=14,<15 `

Result:
**- all-succeeded (except arm64**: `Unsatisfiable dependencies for platform noarch:` nodejs >=14,<15`)