### PR TITLE
jupyterlab_server 2.10.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,9 @@ test:
   commands:
     - python -m pip check
   downstreams:
-    - jupyterlab
+    # Additional testing for downstream package jupyterlab
+    # Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
+    - jupyterlab  # [not (s390x or aarch64 or arm64)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.10.2" %}
-{% set hash = "bf1ec9e49d4e26f14d70055cc293b3f8ec8410f95a4d5b4bd55c442d9b8b266c" %}
+{% set version = "2.10.3" %}
+{% set hash = "3fb84a5813d6d836ceda773fb2d4e9ef3c7944dbc1b45a8d59d98641a80de80a" %}
 
 package:
   name: jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,9 +27,9 @@ requirements:
     - python >=3.6
     - babel
     - entrypoints >=0.2.2
+    - jinja2 >=2.10
     - json5
     - jsonschema >=3.0.1
-    - jinja2 >=2.10
     - jupyter_server >=1.4,<2
     - packaging
     - requests
@@ -37,11 +37,12 @@ requirements:
 test:
   requires:
     - pip
-    - python <3.10
   imports:
     - jupyterlab_server
   commands:
     - python -m pip check
+  downstreams:
+    - jupyterlab
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server


### PR DESCRIPTION
Update jupyterlab_server to 2.10.3

Version change: bump version number from 2.10.2 to 2.10.3
Bug Tracker: new open issues https://github.com/jupyterlab/jupyterlab_server/issues
Github releases:  https://github.com/jupyterlab/jupyterlab_server/releases
Upstream license:  License file:  https://github.com/jupyterlab/jupyterlab_server/blob/master/LICENSE
Upstream Changelog: https://github.com/jupyterlab/jupyterlab_server/blob/main/CHANGELOG.md
Upstream setup.cfg:  https://github.com/jupyterlab/jupyterlab_server/blob/v2.10.3/setup.cfg
Upstream pyproject.toml:  https://github.com/jupyterlab/jupyterlab_server/blob/v2.10.3/pyproject.toml

The package jupyterlab_server is mentioned inside the packages:
jupyterlab |

Actions:
1. Fix python in `test/requires`
2. Add `downstreams` in test: `jupyterlab`
