### PR TITLE
jupyterlab_server 2.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.10.3" %}
-{% set hash = "3fb84a5813d6d836ceda773fb2d4e9ef3c7944dbc1b45a8d59d98641a80de80a" %}
+{% set version = "2.12.0" %}
+{% set hash = "00e0f4b4c399f55938323ea10cf92d915288fe12753e35d1069f6ca08b72abbf" %}
 
 package:
   name: jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,10 @@ test:
     - python -m pip check
   downstreams:
     # Additional testing for downstream package jupyterlab
-    # Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
-    # And skip ppc64le: npm dependencies failed to install
-    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
+    # 1. Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
+    # 2. Skip ppc64le: npm dependencies failed to install
+    # 3. Skip win: false positive jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2.
+    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le or win)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,13 +40,13 @@ test:
   imports:
     - jupyterlab_server
   commands:
-    - python -m pip check
+    # Skip win: false positive jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2.
+    - python -m pip check  # [not win]
   downstreams:
     # Additional testing for downstream package jupyterlab
     # 1. Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
     # 2. Skip ppc64le: npm dependencies failed to install
-    # 3. Skip win: false positive jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2.
-    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le or win)]
+    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
@@ -44,7 +44,8 @@ test:
   downstreams:
     # Additional testing for downstream package jupyterlab
     # Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
-    - jupyterlab  # [not (s390x or aarch64 or arm64)]
+    # And skip ppc64le: npm dependencies failed to install
+    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
-  noarch: python
+  number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
@@ -24,13 +24,13 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - babel
     - entrypoints >=0.2.2
-    - jinja2 >=2.10
+    - jinja2 >=3.0.3
     - json5
     - jsonschema >=3.0.1
-    - jupyter_server >=1.4,<2
+    - jupyter_server >=1.8,<2
     - packaging
     - requests
 


### PR DESCRIPTION
Update jupyterlab_server to 2.12.0

Version change: bump version number from 2.10.3 to 2.12.0
Bug Tracker: new open issues https://github.com/jupyterlab/jupyterlab_server/issues
Github releases: https://github.com/jupyterlab/jupyterlab_server/releases
Upstream license: License file: https://github.com/jupyterlab/jupyterlab_server/blob/master/LICENSE
Upstream Changelog: https://github.com/jupyterlab/jupyterlab_server/blob/main/CHANGELOG.md
Upstream setup.cfg: https://github.com/jupyterlab/jupyterlab_server/blob/v2.12.0/setup.cfg
Upstream pyproject.toml: https://github.com/jupyterlab/jupyterlab_server/blob/v2.12.0/pyproject.toml

The package jupyterlab_server is mentioned inside the packages:
jupyterlab |

Actions:
1. Remove noarch python
2. Skip py<37 and s390x
3. Fix python in run
4. Update jinjs2 and jupyter_server pinnings
5. Skip pip check on win: false-positive (?) jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2. But it hasn't a direct dependency `pywinpty<2` https://github.com/AnacondaRecipes/jupyter_server-feedstock/blob/master/recipe/meta.yaml
6. Skip downstreams on ppc64le: npm dependencies failed to install