### PR TITLE
jupyterlab_server 2.16.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,11 @@ test:
   commands:
     # Skip win: false positive jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2.
     - python -m pip check  # [not win]
-  downstreams:
+  #downstreams:
     # Additional testing for downstream package jupyterlab
     # 1. Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
     # 2. Skip ppc64le: npm dependencies failed to install
-    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
+    #- jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.15.2" %}
-{% set hash = "c0bcdd4606e640e6f16d236ceac55336dc8bf98cbbce067af27524ccc2fb2640" %}
+{% set version = "2.16.3" %}
+{% set hash = "635a0b176a901f19351c02221a124e59317c476f511200409b7d867e8b2905c3" %}
 
 package:
   name: jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,6 +65,3 @@ extra:
     - SylvainCorlay
     - bollwyvl
     - jtpio
-
-skip-lints:
-  - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  # jupyterlab_server isn't available on s390x yet.
   skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -19,15 +20,17 @@ requirements:
   host:
     - python
     - pip
-    - hatchling >=0.25
+    - hatchling
+    - setuptools
+    - wheel
   run:
     - python
     - babel
-    - importlib-metadata >=3.6  # [py<310]
+    - importlib-metadata >=4.8.3  # [py<310]
     - jinja2 >=3.0.3
     - json5
     - jsonschema >=3.0.1
-    - jupyter_server >=1.8,<2
+    - jupyter_server >=1.8,<3
     - packaging
     - requests
 
@@ -62,3 +65,6 @@ extra:
     - SylvainCorlay
     - bollwyvl
     - jtpio
+
+skip-lints:
+  - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,11 @@ test:
   commands:
     # Skip win: false positive jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2.
     - python -m pip check  # [not win]
-#  downstreams:
+  downstreams:
     # Additional testing for downstream package jupyterlab
     # 1. Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
     # 2. Skip ppc64le: npm dependencies failed to install
-#    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
+    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server


### PR DESCRIPTION
**Jira ticket:** [PKG-778](https://anaconda.atlassian.net/browse/PKG-778) (jupyterlab_server-2.16.3)

**The upstream data:**
Github releases:  https://github.com/jupyterlab/jupyterlab_server/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyterlab/jupyterlab_server/compare/v2.12.0...v2.16.3)
License: https://github.com/jupyterlab/jupyterlab_server/blob/master/LICENSE
Changelog: https://github.com/jupyterlab/jupyterlab_server/blob/main/CHANGELOG.md
Requirements:
 *  pyproject.toml:  https://github.com/jupyterlab/jupyterlab_server/blob/v2.16.3/pyproject.toml

**_Actions:_**

1. Remove pinning for `hatchling` in `host` because we have **v1.8.0** as a minimum in the default channel
2. Add explicitly `setuptools` and `wheel` to `host`
3. Update pinnings in `run`

**_Notes:_**
 * The downstream package `jupyterlab` has been tested successfully.

**Package's statistics**
<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.16.3
 * Release on PyPi:
    * version: 2.16.3
    * date: 2022-11-11T02:56:55
* [PyPi history](https://pypi.org/project/jupyterlab_server/#history)
 * Popularity: 
    * 3 months downloads: 701582.0
    * All time:  3412510 downloads -  jupyterlab_server  2.16.3  A set of server components for JupyterLab and JupyterLab like applications.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jupyterlab/jupyterlab_server/tree/v2.16.3 exists
4. - [x] https://github.com/jupyterlab/jupyterlab_server is present
5. - [x] Check the pinnings
6. - [x] https://github.com/jupyterlab/jupyterlab_server/blob/main/CHANGELOG.md exists
7. - [x] Additional research
    https://github.com/jupyterlab/jupyterlab_server/issues
    200
8. - [x] `dev_url` is present
    https://github.com/jupyterlab/jupyterlab_server
9. - [x] `doc_url` is present
    https://jupyterlab-server.readthedocs.io/en/stable/
10. - [x] Verify that the `build_number` is correct
11. - [x] has `setuptools`
12. - [x] has `wheel`
13. - [x] `pip` in test
14. - [x] Verify the test section
15. - [x] Verify if the package is `architecture specific`
16. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
17.  - [x] license_file: LICENSE is present
18. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

19. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/tree/2.16.3)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyterlab_server)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyterlab_server-feedstock/compare/main...AnacondaRecipes:2.16.3)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/compare/master...AnacondaRecipes:2.16.3)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.16.3 git@github.com:AnacondaRecipes/jupyterlab_server-feedstock.git
```
