### PR TITLE
jupyterlab_server 2.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,13 +39,12 @@ test:
   imports:
     - jupyterlab_server
   commands:
-    # Skip `win` platform: false positive jupyter-server 1.13.5 has requirement pywinpty<2 but you have pywinpty 2.0.2.
-    - python -m pip check  # [not win]
-  downstreams:
+    - python -m pip check 
+  # downstreams:
     # Additional testing for downstream package jupyterlab
     # 1. Skip s390x and arm64 because nodejs >=14,<15 currently isn't available.
     # 2. Skip ppc64le: npm dependencies failed to install
-    - jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
+    #- jupyterlab  # [not (s390x or aarch64 or arm64 or ppc64le)]
 
 about:
   home: https://github.com/jupyterlab/jupyterlab_server

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab_server" %}
-{% set version = "2.16.5" %}
+{% set version = "2.19.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 61381c48268f0a8a84a27858b49db1b02e5aec6549e85e22fcdbf3eb14a2193a
+  sha256: 9aec21a2183bbedd9f91a86628355449575f1862d88b28ad5f905019d31e6c21
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - importlib-metadata >=4.8.3  # [py<310]
     - jinja2 >=3.0.3
     - json5 >=0.9.0
-    - jsonschema >=3.0.1
+    - jsonschema >=4.17.3
     - jupyter_server >=1.21,<3
     - packaging >=21.3
     - requests >=2.28


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index a9a97fb..5fd30e9 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab_server" %}
-{% set version = "2.16.5" %}
+{% set version = "2.19.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 61381c48268f0a8a84a27858b49db1b02e5aec6549e85e22fcdbf3eb14a2193a
+  sha256: 9aec21a2183bbedd9f91a86628355449575f1862d88b28ad5f905019d31e6c21
 
 build:
   number: 0

```

**Jira ticket:** [PKG-939](https://anaconda.atlassian.net/browse/PKG-939)

**The upstream data:**
Github releases:  https://github.com/jupyterlab/jupyterlab_server/releases
[Diff between the latest and previous upstream releases](https://github.com/jupyterlab/jupyterlab_server/compare/2.16.5...2.19.0)
Changelog: https://github.com/jupyterlab/jupyterlab_server/blob/main/CHANGELOG.md
Requirements:
 *  pyproject.toml:  https://github.com/jupyterlab/jupyterlab_server/blob/v2.19.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.19.0
 * Release on PyPi:
    * version: 2.19.0
    * date: 2023-01-16T12:39:28
* [PyPi history](https://pypi.org/project/jupyterlab_server/#history)
 * Popularity: 
    * 3 months downloads: 985915.0
    * All time:  3843601 downloads -  jupyterlab_server  2.19.0  A set of server components for JupyterLab and JupyterLab like applications.  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
8. - [ ] NO `pip` in test
    python
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/jupyterlab_server-feedstock/recipe/meta.yaml
Dependencies: ['babel >=2.10', 'hatchling', 'wheel', 'jsonschema >=3.0.1', 'json5 >=0.9.0', 'requests >=2.28', 'jinja2 >=3.0.3', 'pip', 'jupyter_server >=1.21,<3', 'setuptools', 'packaging >=21.3', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 18**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/tree/2.19.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/jupyterlab_server)
* [Diff between upstream and feature branch](https://github.com/conda-forge/jupyterlab_server-feedstock/compare/main...AnacondaRecipes:2.19.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/compare/master...AnacondaRecipes:2.19.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/jupyterlab_server-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.19.0 git@github.com:AnacondaRecipes/jupyterlab_server-feedstock.git
```
