### PR TITLE
jupyterlab_server update to v 2.21.0:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,6 @@ test:
   imports:
     - jupyterlab_server
   commands:
-    - pip check
     - python -m pip check 
   # downstreams:
     # Additional testing for downstream package jupyterlab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterlab_server" %}
-{% set version = "2.19.0" %}
+{% set version = "2.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9aec21a2183bbedd9f91a86628355449575f1862d88b28ad5f905019d31e6c21
+  sha256: b4f5b48eaae1be83e2fd6fb77ac49d9b639be4ca4bd2e05b5368d29632a93725
 
 build:
-  # trigger 1
   number: 0
-  # jupyterlab_server isn't available on s390x yet.
-  skip: True  # [py<37 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv
 
 requirements:
   host:
     - python
     - pip
-    - hatchling
+    - hatchling 1.8
     - setuptools
     - wheel
   run:
@@ -40,6 +38,7 @@ test:
   imports:
     - jupyterlab_server
   commands:
+    - pip check
     - python -m pip check 
   # downstreams:
     # Additional testing for downstream package jupyterlab
@@ -53,6 +52,10 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: A set of server components for JupyterLab and JupyterLab like applications.
+  description: |
+    JupyterLab Server sits between JupyterLab and Jupyter Server, and provides a set of REST API handlers 
+    and utilities that are used by JupyterLab. It is a separate project in order to accommodate creating 
+    JupyterLab-like applications from a more limited scope.
   dev_url: https://github.com/jupyterlab/jupyterlab_server
   doc_url: https://jupyterlab-server.readthedocs.io
 


### PR DESCRIPTION
 - version bumped up and sha256 updated
 - allow building on s390x
 - pin hatchling package
 - add pip check to test commands
 - add description in the 'about' section